### PR TITLE
SUP-7088: Update Add node instructions

### DIFF
--- a/docs/devops.md
+++ b/docs/devops.md
@@ -105,6 +105,7 @@ If you are creating a temporary domain, use the pattern `[namespace]-i2`. If cre
 9. Shell into the `arca-dc` server, and add the node to the cluster:
     - `microk8s add-node`
     - Copy the `microk8s join` command it generates.
+    - Use the `--worker` flag unless you specifically need the node to be a master node. New nodes should be workers by default.
 10. Shell into the new server, and paste the `microk8s join` command from the previous step.
     - If there's a timeout error, there is probably a firewall issue between the servers; contact SFU to deal with it.
 11. On the `arca-dc` server, confirm the node has been added with `kubectl get nodes`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for adding a new node to the Kubernetes cluster, clarifying the use of the `--worker` flag when joining nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->