### PR TITLE
Correct kubectl command formatting in migration_cleanup.md

### DIFF
--- a/docs/migration_cleanup.md
+++ b/docs/migration_cleanup.md
@@ -35,7 +35,7 @@ are no longer relevant.
 
 Where `kubectl` is installed
 ```bash
-kubectl exec --stdin --tty deployments/activemq -- bin/activemq purge $QUEUE_NAME
+kubectl exec -n [namespace] deployments/activemq -- env JAVA_OPTS="" ACTIVEMQ_OPTS="" bin/activemq purge islandora-connector-hypercube
 ```
 
 Where `$QUEUE_NAME` is replaced by the queue looking to be purged, this is

--- a/docs/migration_cleanup.md
+++ b/docs/migration_cleanup.md
@@ -10,7 +10,7 @@ ensure the system is ready for production use.
 To monitor the queue you can use the following command where `kubectl` is
 installed.
 ```bash
-kubectl exec -n [namespace] deployments/activemq --   env JAVA_OPTS="" ACTIVEMQ_OPTS="" bin/activemq query -QQueue=islandora* --view Name,QueueSize
+kubectl exec -n [namespace] deployments/activemq -- env JAVA_OPTS="" ACTIVEMQ_OPTS="" bin/activemq query -QQueue=islandora* --view Name,QueueSize
 ```
 This will show the remaining items on all of the Islandora derivative queues.
 


### PR DESCRIPTION
Fix formatting of ActiveMQ purge command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized whitespace and formatting in migration command examples for clarity.
  * Updated purge command example to show a namespace-scoped invocation that targets a specific queue.
  * Added an example showing environment variable initialization when running purge operations to improve reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->