### PR TITLE
BCELN2-384: Update export-config.sh to support Argo Workflow and CronJob

### DIFF
--- a/docs/resources/devops_scripts/export-config.sh
+++ b/docs/resources/devops_scripts/export-config.sh
@@ -3,13 +3,57 @@ set -euo pipefail
 
 ns=${1?"A namespace is required"}
 
+workflow_template_name="drupal-export-config"
 cronjob_name="bceln-drupal-config-export-cron"
+
+# Check if the Argo WorkflowTemplate exists (post-migration clusters)
+wf_exists=$(kubectl get workflowtemplate "$workflow_template_name" -n "$ns" --ignore-not-found -o name 2>/dev/null || echo "")
+
+if [[ -n "$wf_exists" ]]; then
+  echo "Submitting Argo WorkflowTemplate '$workflow_template_name' in namespace '$ns'..."
+  workflow_name=$(kubectl create -n "$ns" -o jsonpath='{.metadata.name}' -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ${workflow_template_name}-
+spec:
+  workflowTemplateRef:
+    name: ${workflow_template_name}
+EOF
+)
+  echo "Workflow '$workflow_name' created. Waiting for completion..."
+
+  for i in {1..60}; do
+    phase=$(kubectl get workflow "$workflow_name" -n "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [[ "$phase" == "Succeeded" ]]; then
+      break
+    elif [[ "$phase" == "Failed" || "$phase" == "Error" ]]; then
+      echo "Workflow failed (phase: $phase)."
+      kubectl logs -n "$ns" -l workflows.argoproj.io/workflow="$workflow_name" --prefix || true
+      exit 1
+    fi
+    sleep 10
+  done
+
+  phase=$(kubectl get workflow "$workflow_name" -n "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  if [[ "$phase" == "Succeeded" ]]; then
+    echo "Workflow succeeded. Logs:"
+    kubectl logs -n "$ns" -l workflows.argoproj.io/workflow="$workflow_name" --prefix || true
+    exit 0
+  else
+    echo "Workflow did not complete successfully (phase: ${phase:-timeout})."
+    kubectl logs -n "$ns" -l workflows.argoproj.io/workflow="$workflow_name" --prefix || true
+    exit 1
+  fi
+fi
+
+# Fall back to CronJob-based approach for clusters not yet migrated
 job_name="${ns}-config-export-$(date +%s)"
 
 # Check if the CronJob exists and is enabled (suspend=false)
 cronjob_status=$(kubectl get cronjob "$cronjob_name" -n "$ns" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "notfound")
 if [[ "$cronjob_status" == "notfound" ]]; then
-  echo "CronJob '$cronjob_name' does not exist in namespace '$ns'."
+  echo "Neither WorkflowTemplate '$workflow_template_name' nor CronJob '$cronjob_name' found in namespace '$ns'."
   exit 1
 elif [[ "$cronjob_status" == "true" ]]; then
   echo "CronJob '$cronjob_name' is currently suspended (disabled) in namespace '$ns'."
@@ -40,10 +84,11 @@ job_status=$(kubectl get job $job_name -n $ns -o jsonpath='{.status.succeeded}' 
 if [[ "$job_status" == "1" ]]; then
   pod_name=$(kubectl get pods -n $ns --selector=job-name=$job_name -o jsonpath='{.items[0].metadata.name}')
   echo "Job succeeded. Tailing logs:"
-  kubectl logs -f -n "$ns" "$pod_name"
+  kubectl logs -n "$ns" "$pod_name"
   kubectl delete job "$job_name" -n "$ns" --wait=false
   exit 0
 else
   echo "Job did not complete successfully (timeout or unknown error)."
   kubectl logs -n "$ns" -l job-name=$job_name || true
+  exit 1
 fi

--- a/docs/resources/devops_scripts/export-config.sh
+++ b/docs/resources/devops_scripts/export-config.sh
@@ -72,7 +72,7 @@ for i in {1..60}; do
     break
   elif [[ "$job_status" == *"Failed"* ]]; then
     echo "Job failed."
-    kubectl logs -n "$ns" -l job-name=$job_name || true
+    kubectl logs -n "$ns" -l "job-name=$job_name" || true
     exit 1
   fi
   sleep 10
@@ -89,6 +89,6 @@ if [[ "$job_status" == "1" ]]; then
   exit 0
 else
   echo "Job did not complete successfully (timeout or unknown error)."
-  kubectl logs -n "$ns" -l job-name=$job_name || true
+  kubectl logs -n "$ns" -l "job-name=$job_name" || true
   exit 1
 fi

--- a/docs/resources/devops_scripts/export-config.sh
+++ b/docs/resources/devops_scripts/export-config.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 ns=${1?"A namespace is required"}
 
 workflow_template_name="drupal-export-config"
-cronjob_name="bceln-drupal-config-export-cron"
 
 # Check if the Argo WorkflowTemplate exists (post-migration clusters)
 wf_exists=$(kubectl get workflowtemplate "$workflow_template_name" -n "$ns" --ignore-not-found -o name 2>/dev/null || echo "")
@@ -50,12 +49,17 @@ fi
 # Fall back to CronJob-based approach for clusters not yet migrated
 job_name="${ns}-config-export-$(date +%s)"
 
-# Check if the CronJob exists and is enabled (suspend=false)
-cronjob_status=$(kubectl get cronjob "$cronjob_name" -n "$ns" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "notfound")
-if [[ "$cronjob_status" == "notfound" ]]; then
-  echo "Neither WorkflowTemplate '$workflow_template_name' nor CronJob '$cronjob_name' found in namespace '$ns'."
+# Detect the config export CronJob by pattern
+cronjob_name=$(kubectl get cronjob -n "$ns" -o name 2>/dev/null | grep "config-export-cron" | head -1 | sed 's|.*/||')
+
+if [[ -z "$cronjob_name" ]]; then
+  echo "Neither WorkflowTemplate '$workflow_template_name' nor a config-export CronJob found in namespace '$ns'."
   exit 1
-elif [[ "$cronjob_status" == "true" ]]; then
+fi
+
+# Check CronJob is not suspended
+cronjob_status=$(kubectl get cronjob "$cronjob_name" -n "$ns" -o jsonpath='{.spec.suspend}' 2>/dev/null || echo "notfound")
+if [[ "$cronjob_status" == "true" ]]; then
   echo "CronJob '$cronjob_name' is currently suspended (disabled) in namespace '$ns'."
   exit 1
 fi


### PR DESCRIPTION
## Summary

- The config export CronJob has been migrated to an Argo `WorkflowTemplate` (`drupal-export-config`) on updated namespaces
- Script now detects which approach to use: if the `WorkflowTemplate` exists in the namespace, it submits a `Workflow` via `kubectl create` and polls for completion; otherwise falls back to the existing CronJob logic
- Uses pure `kubectl` — no `argo` CLI dependency
- Also fixes two minor bugs in the original CronJob path: `kubectl logs -f` (could hang on completed pods) replaced with `kubectl logs`, and missing `exit 1` on timeout

## Test plan

- [ ] Run against a migrated site (with WorkflowTemplate present) — should submit workflow and stream logs
- [ ] Run against a non-migrated site (CronJob still in place) — should follow existing CronJob path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Argo WorkflowTemplate-based configuration exports with automatic polling and success verification.

* **Bug Fixes**
  * Improved fallback behavior to use a CronJob only when no WorkflowTemplate is found and report clearly when neither exists.
  * Consistent non-zero exits and clearer logs on failure or timeout.

* **Chores**
  * Adjusted logging to avoid indefinite streaming after successful runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->