### PR TITLE
SUPM-1639: Bump core version requirement spec to support D11.

### DIFF
--- a/bcelndora.info.yml
+++ b/bcelndora.info.yml
@@ -1,7 +1,7 @@
 name: 'BCELN Customizations'
 type: module
 description: 'Customizations for the BCELN Islandora installation.'
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 package: DGI
 dependencies:
   - drupal:migrate


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended support for Drupal 11 while maintaining Drupal 10 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->